### PR TITLE
remove mageekguy from namespace

### DIFF
--- a/.atoum.php
+++ b/.atoum.php
@@ -2,6 +2,5 @@
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
 
-use mageekguy\atoum\ruler;
-$runner->addExtension(new ruler\extension($script));
+$runner->addExtension(new \atoum\ruler\extension($script));
 $runner->addTestsFromDirectory(__DIR__ . '/tests/units');

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Enable the extension using atoum configuration file:
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
 
-$runner->addExtension(new \mageekguy\atoum\ruler\extension($script));
+$runner->addExtension(new \atoum\ruler\extension($script));
 ```
 
 ## Use it

--- a/classes/extension.php
+++ b/classes/extension.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\ruler;
+namespace atoum\ruler;
 
-use mageekguy\atoum;
 use mageekguy\atoum\observable;
+use mageekguy\atoum\configurator;
 use mageekguy\atoum\runner;
-use mageekguy\atoum\exceptions\logic\invalidArgument;
+use atoum\exceptions\logic\invalidArgument;
 use mageekguy\atoum\test;
 
-class extension implements atoum\extension
+class extension implements \atoum\extension
 {
 	/**
 	 * @var string|null
@@ -17,16 +17,16 @@ class extension implements atoum\extension
 
 
 	/**
-	 * @param atoum\configurator $configurator
+	 * @param configurator $configurator
 	 */
-	public function __construct(atoum\configurator $configurator = null)
+	public function __construct(configurator $configurator = null)
 	{
 		if ($configurator)
 		{
 			$script = $configurator->getScript();
 			$parser = $script->getArgumentsParser();
 			$extension = $this;
-			$handler = function(atoum\scripts\runner $script, $argument, $values) use ($extension) {
+			$handler = function(\atoum\scripts\runner $script, $argument, $values) use ($extension) {
 				if (sizeof($values) != 1)
 				{
 					throw new invalidArgument(sprintf($script->getLocale()->_('Bad usage of %s, do php %s --help for more informations'), $argument, $script->getName()));

--- a/classes/ruler.php
+++ b/classes/ruler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace mageekguy\atoum\ruler;
+namespace atoum\ruler;
 
 use mageekguy\atoum\test;
 use Hoa\Ruler\Context as HoaContext;

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "autoload": {
         "psr-4": {
-            "mageekguy\\atoum\\ruler\\": "classes"
+            "atoum\\ruler\\": "classes"
         },
         "files": ["autoloader.php"]
     }

--- a/tests/units/classes/ruler.php
+++ b/tests/units/classes/ruler.php
@@ -1,20 +1,17 @@
 <?php
 
-namespace mageekguy\atoum\ruler\tests\units;
+namespace atoum\ruler\tests\units;
 
-use
-	mageekguy\atoum,
-	mageekguy\atoum\ruler\ruler as testedClass
-	;
+use atoum\ruler\ruler as testedClass;
 
-class ruler extends atoum\test
+class ruler extends \atoum\test
 {
 	/**
 	 * @dataProvider testFilterDataProvider
 	 */
 	public function testIsMethodIgnored($case, $rules)
 	{
-		$test = new \mock\mageekguy\atoum\test();
+		$test = new \mock\atoum\test();
 
 		$test->getMockController()->getTestMethods = array_keys($case['methodTags']);
 		$test->getMockController()->getClass = $case['class'];


### PR DESCRIPTION
fixes issue #4

I had to keep some references to the mageekguy namespace to avoid errors like this :

```
Error: Argument 1 passed to atoum\ruler\extension::__construct() must be an instance of atoum\configurator, instance of mageekguy\atoum\configurator given, called in /home/agallou/Projets/atoum-hoa-ruler/.atoum.php on line 5 and defined in /home/agallou/Projets/atoum-hoa-ruler/.atoum.php at line 5
```
