### PR TITLE
Move to Hoa\Ustring.

### DIFF
--- a/autoloader.php
+++ b/autoloader.php
@@ -26,6 +26,6 @@ atoum\autoloader::get()
 	->addDirectory('Hoa\Regex', $vendorDirectory . '/hoa/regex')
 	->addDirectory('Hoa\Ruler', $vendorDirectory . '/hoa/ruler')
 	->addDirectory('Hoa\Stream', $vendorDirectory . '/hoa/stream')
-	->addDirectory('Hoa\String', $vendorDirectory . '/hoa/string')
+	->addDirectory('Hoa\Ustring', $vendorDirectory . '/hoa/ustring')
 	->addDirectory('Hoa\Visitor', $vendorDirectory . '/hoa/visitor')
 ;


### PR DESCRIPTION
Hi,
Since https://github.com/hoaproject/Regex/commit/17bd41d2ae876a8e2736fddf40c01fb956527422#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780R26 composer install Hoa/Ustring instead of Hoa/String.
