### PR TITLE
add filter on extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # `dev-master`
 
 * [#24](https://github.com/atoum/ruler-extension/pull/24) Add a contain operator ([@agallou])
+* [#20](https://github.com/atoum/ruler-extension/pull/20) Add a filter on extensions ([@agallou])
 
 # 1.0.3 - 2015-06-24
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Those variables are available in the filter:
 * `testedclass`
 * `testedclassnamespace`
 * `tags` (as an array)
+* `extensions` (as an array)
 
 ## Examples
 
@@ -105,4 +106,10 @@ Run the tests that test the classes in the `mageekguy\atoum\ruler` namespace:
 
 ```
 ./vendor/bin/atoum -d tests --filter 'testedclassnamespace = "mageekguy\atoum\ruler'
+```
+
+Run all tests that needs the blackfire extension :
+
+```
+./vendor/bin/atoum -d tests --filter '"blackfire" in extensions'
 ```

--- a/classes/ruler.php
+++ b/classes/ruler.php
@@ -46,6 +46,10 @@ class ruler
 			$contexts[$methodName]['testedclassnamespace'] = $test->getTestedClassNamespace();
 		}
 
+		foreach ($test->getMandatoryMethodExtensions() as $methodName => $extensions) {
+			$contexts[$methodName]['extensions'] = $extensions;
+		}
+
 		foreach ($test->getMethodTags() as $methodName => $tags) {
 			$contexts[$methodName]['tags'] = $tags;
 		}

--- a/tests/units/classes/ruler.php
+++ b/tests/units/classes/ruler.php
@@ -22,6 +22,8 @@ class ruler extends atoum\test
 		$test->getMockController()->getTestedClassName = $case['testedClassName'];
 		$test->getMockController()->getTestedClassNameNamespace = $case['testedClassNamespace'];
 		$test->getMockController()->getMethodTags = $case['methodTags'];
+		$test->getMockController()->getMandatoryMethodExtensions = $case['mandatoryMethodExtensions'];
+
 
 		foreach ($rules as $rule => $methodCases) {
 			$testedClass = new testedClass($rule);
@@ -48,6 +50,11 @@ class ruler extends atoum\test
 			'classNamespace' => 'mageekguy\atoum\ruler\tests\units',
 			'testedClassName' => 'mageekguy\atoum\ruler\testClass1',
 			'testedClassNamespace' => 'mageekguy\atoum\ruler',
+			'mandatoryMethodExtensions' => array(
+				'testMethod1' => array(
+					'opcache',
+				),
+			),
 		);
 
 		//rule.method => isMethodIgnored
@@ -57,6 +64,12 @@ class ruler extends atoum\test
 			),
 			'not(tags contains "unSuperTagAuNiveauDeLaMethode1")' => array(
 				'testMethod1' => true,
+			),
+			'not("opcache" in extensions)' => array(
+				'testMethod1' => true,
+			),
+			'"opcache" in extensions' => array(
+				'testMethod1' => false,
 			),
 			'method = "testMethod1"' => array(
 				'testMethod1' => false,


### PR DESCRIPTION
It's now possible to add a filter on an extension.

atoum as a mechanism to ignore some tests if a php extension
is not loaded. For example :

``` php
/**
 * @extensions blackfire
 */
class Example extends atoum
```

This change adds an extension variable to the filter rule.

You can now, for example launch only the tests that needs the blackfire
extension :

```
./vendor/bin/atoum -d tests --filter '"blackfire" in extensions'
```
