### PR TITLE
Fix minimum version on dependancies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,10 @@
 {
     "name": "atoum/ruler-extension",
     "require": {
-        "atoum/atoum": "<3.0",
-        "hoa/ruler": "~1.0"
+        "atoum/atoum": ">=1.0,<3.0",
+        "hoa/ruler": ">=1.15.11.09,<2.0",
+        "hoa/regex": ">=0.15.05.29,<1.0",
+        "hoa/core": ">=2.14.12.10,<3.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
We need at least atoum/atoum. version 1.0. Without that we'll get this error :

```
PHP Fatal error:  Call to undefined method mageekguy\atoum\runner::addExtension() in /home/agallou/Projets/atoum-hoa-ruler/.atoum.php on line 7
```

We need at least hoa/ruler 1.15.11.09. Without that we'll get this error :

```
Call to undefined method Hoa\Ruler\Ruler::interpret()
```

We need at least hoa/regex 0.15.05.29. Without that, we'll get this error :

```
UnexpectedValueException' with message 'RecursiveDirectoryIterator::__construct(/home/agallou/Projets/atoum-hoa-ruler/vendor/hoa/ustring/): failed to open dir: No such file or directory'
```

And finally, we need hoa/core 2.14.12.10. otherwise this happens :

```
Hoa\File\File::_open(): (1) Failed to open stream hoa://Library/Ruler/Grammar.pp.
```

This errors (which can be reproduced by a `composer update --prefer-lowest && ./vendor/bin/atoum`), can be fixed by setting the minimum dependancies in the composer.json.

@Hywan  this should not be defined in a projet that requires hoa/ruler. There may be something to do on that on hoa.
