### PR TITLE
add filter on php version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Those variables are available in the filter:
 * `testedclass`
 * `testedclassnamespace`
 * `tags` (as an array)
+* `phpVersionConstraint`
+  * `.hasGte`
+  * `.hasGt`
+  * `.hasEq`
+  * `.hasLt`
+  * `.hasLte`
 
 ## Examples
 
@@ -94,4 +100,23 @@ Run the tests that test the classes in the `mageekguy\atoum\ruler` namespace:
 
 ```
 ./vendor/bin/atoum -d tests --filter 'testedclassnamespace = "mageekguy\atoum\ruler'
+```
+
+### PHP Version constraint
+
+Run the tests that that has a constraint on greater equal than PHP 7:
+
+```
+./vendor/bin/atoum -d tests --filter 'phpVersionConstraint.hasGte("7.0")'
+```
+
+The constraint on the test is added like this :
+```php
+    /**
+     * @php >= 7.0
+     */
+    public function testMethod()
+    {
+       //test content
+    }
 ```

--- a/classes/phpVersionConstraint.php
+++ b/classes/phpVersionConstraint.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace mageekguy\atoum\ruler;
+
+class phpVersionConstraint
+{
+	/**
+	 * @var array
+	 */
+	protected $versions;
+
+	/**
+	 * @param array $versions
+	 */
+	public function __construct(array $versions)
+	{
+		$this->versions = $versions;
+	}
+
+	/**
+	 * @param string $version
+	 *
+	 * @return bool
+	 */
+	public function containsGte($version)
+	{
+		return $this->compare($version, '>=');
+	}
+
+	/**
+	 * @param string $version
+	 *
+	 * @return bool
+	 */
+	public function containsGt($version)
+	{
+		return $this->compare($version, '>');
+	}
+
+	/**
+	 * @param string $version
+	 *
+	 * @return bool
+	 */
+	public function containsEq($version)
+	{
+		return $this->compare($version, '=');
+	}
+
+	/**
+	 * @param string $version
+	 *
+	 * @return bool
+	 */
+	public function containsLt($version)
+	{
+		return $this->compare($version, '<');
+	}
+
+	/**
+	 * @param string $version
+	 *
+	 * @return bool
+	 */
+	public function containsLte($version)
+	{
+		return $this->compare($version, '<=');
+	}
+
+	/**
+	 * @param string $version
+	 * @param string $operator
+	 *
+	 * @return bool
+	 */
+	private function compare($version, $operator)
+	{
+		return array_key_exists($version, $this->versions) && $this->versions[$version] == $operator;
+	}
+}

--- a/classes/ruler.php
+++ b/classes/ruler.php
@@ -43,6 +43,7 @@ class ruler
 			$contexts[$methodName]['namespace'] = $test->getClassNamespace();
 			$contexts[$methodName]['testedclass'] = $test->getTestedClassName();
 			$contexts[$methodName]['testedclassnamespace'] = $test->getTestedClassNamespace();
+			$contexts[$methodName]['phpVersionConstraint'] = new phpVersionConstraint($test->getMethodPhpVersions($methodName));
 		}
 
 		foreach ($test->getMethodTags() as $methodName => $tags) {

--- a/tests/units/classes/ruler.php
+++ b/tests/units/classes/ruler.php
@@ -16,12 +16,19 @@ class ruler extends atoum\test
 	{
 		$test = new \mock\mageekguy\atoum\test();
 
-		$test->getMockController()->getTestMethods = array_keys($case['methodTags']);
+		$test->getMockController()->getTestMethods = $case['testMethods'];
 		$test->getMockController()->getClass = $case['class'];
 		$test->getMockController()->getClassNamespace = $case['classNamespace'];
 		$test->getMockController()->getTestedClassName = $case['testedClassName'];
 		$test->getMockController()->getTestedClassNameNamespace = $case['testedClassNamespace'];
 		$test->getMockController()->getMethodTags = $case['methodTags'];
+		$this->calling($test)->getMethodPhpVersions = function($methodName) use ($case) {
+			if (!isset($case['methodPhpVersions'][$methodName])) {
+				return array();
+			}
+
+			return $case['methodPhpVersions'][$methodName];
+		};
 
 		foreach ($rules as $rule => $methodCases) {
 			$testedClass = new testedClass($rule);
@@ -39,6 +46,9 @@ class ruler extends atoum\test
 		$data = array();
 
 		$case = array(
+			'testMethods' => array(
+				'testMethod1',
+			),
 			'methodTags' => array(
 				'testMethod1' => array(
 					'unSuperTagAuNiveauDeLaMethode1'
@@ -48,6 +58,7 @@ class ruler extends atoum\test
 			'classNamespace' => 'mageekguy\atoum\ruler\tests\units',
 			'testedClassName' => 'mageekguy\atoum\ruler\testClass1',
 			'testedClassNamespace' => 'mageekguy\atoum\ruler',
+			'methodPhpVersions' => array(),
 		);
 
 		//rule.method => isMethodIgnored
@@ -78,6 +89,102 @@ class ruler extends atoum\test
 			),
 			'testedclassnamespace = "mageekguy\atoum\ruler"' => array(
 				'testMethod1' => false,
+			),
+		);
+
+		$data[] = array($case, $rules);
+
+		$case['testMethods'][] = 'testMethod2';
+		$case['testMethods'][] = 'testMethod3';
+		$case['testMethods'][] = 'testMethod4';
+		$case['testMethods'][] = 'testMethod5';
+		$case['testMethods'][] = 'testMethod6';
+		$case['testMethods'][] = 'testMethod7';
+		$case['methodPhpVersions'] = array(
+			'testMethod2' => array(
+				'7.0' => '>='
+			),
+			'testMethod3' => array(
+				'5.5' => '>'
+			),
+			'testMethod4' => array(
+				'5.4' => '='
+			),
+			'testMethod5' => array(
+				'5.3' => '<'
+			),
+			'testMethod6' => array(
+				'5.2' => '<='
+			),
+			'testMethod7' => array(
+				'5.3' => '<=',
+				'5.5' => '=',
+			),
+		);
+
+		$rules = array(
+			'phpVersionConstraint.containsGte("7.0")' => array(
+				'testMethod1' => true,
+				'testMethod2' => false,
+				'testMethod3' => true,
+				'testMethod4' => true,
+				'testMethod5' => true,
+				'testMethod6' => true,
+				'testMethod7' => true,
+			),
+			'phpVersionConstraint.containsGt("5.5")' => array(
+				'testMethod1' => true,
+				'testMethod2' => true,
+				'testMethod3' => false,
+				'testMethod4' => true,
+				'testMethod5' => true,
+				'testMethod6' => true,
+				'testMethod7' => true,
+			),
+			'phpVersionConstraint.containsEq("5.4")' => array(
+				'testMethod1' => true,
+				'testMethod2' => true,
+				'testMethod3' => true,
+				'testMethod4' => false,
+				'testMethod5' => true,
+				'testMethod6' => true,
+				'testMethod7' => true,
+			),
+			'phpVersionConstraint.containsLt("5.3")' => array(
+				'testMethod1' => true,
+				'testMethod2' => true,
+				'testMethod3' => true,
+				'testMethod4' => true,
+				'testMethod5' => false,
+				'testMethod6' => true,
+				'testMethod7' => true,
+			),
+			'phpVersionConstraint.containsLte("5.2")' => array(
+				'testMethod1' => true,
+				'testMethod2' => true,
+				'testMethod3' => true,
+				'testMethod4' => true,
+				'testMethod5' => true,
+				'testMethod6' => false,
+				'testMethod7' => true,
+			),
+			'phpVersionConstraint.containsEq("5.5")' => array(
+				'testMethod1' => true,
+				'testMethod2' => true,
+				'testMethod3' => true,
+				'testMethod4' => true,
+				'testMethod5' => true,
+				'testMethod6' => true,
+				'testMethod7' => false,
+			),
+			'phpVersionConstraint.containsLte("5.3")' => array(
+				'testMethod1' => true,
+				'testMethod2' => true,
+				'testMethod3' => true,
+				'testMethod4' => true,
+				'testMethod5' => true,
+				'testMethod6' => true,
+				'testMethod7' => false,
 			),
 		);
 


### PR DESCRIPTION
We will now be able to limit the tests launched, on the php version
constraint.

For exemple : `phpVersionConstraint.containsGte("7.0")`.
