### PR TITLE
add a contain operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# `dev-master`
+
+* [#24](https://github.com/atoum/ruler-extension/pull/24) Add a contain operator ([@agallou])
+
 # 1.0.3 - 2015-06-24
 
 * [#17](https://github.com/atoum/ruler-extension/pull/17) Move to Hoa\Ustring ([@Metalaka](https://github.com/Metalaka))

--- a/README.md
+++ b/README.md
@@ -46,8 +46,15 @@ Those variables are available in the filter:
 Run all tests except those who have the `needsDatabase` tag:
 
 ```
+./vendor/bin/atoum -d tests --filter 'not (tags contains "needsDatabase")'
+```
+
+You can also use the ruler's default `in` operator, but in that case that's less readable:
+
+```
 ./vendor/bin/atoum -d tests --filter 'not ("needsDatabase" in tags)'
 ```
+
 
 Run all tests with a method named `testMethod1`:
 

--- a/classes/ruler.php
+++ b/classes/ruler.php
@@ -25,6 +25,7 @@ class ruler
 	{
 		$this->rule = HoaRuler::interpret($rule);
 		$this->ruler = new HoaRuler();
+		$this->ruler->getAsserter()->setOperator('contains',  function (Array $a,  $b) { return in_array($b, $a); });
 	}
 
 	/**

--- a/tests/units/classes/ruler.php
+++ b/tests/units/classes/ruler.php
@@ -55,6 +55,9 @@ class ruler extends atoum\test
 			'not("unSuperTagAuNiveauDeLaMethode1" in tags)' => array(
 				'testMethod1' => true,
 			),
+			'not(tags contains "unSuperTagAuNiveauDeLaMethode1")' => array(
+				'testMethod1' => true,
+			),
 			'method = "testMethod1"' => array(
 				'testMethod1' => false,
 			),


### PR DESCRIPTION
This operator is will improve the readability of the tags filter.

Before, we needed to write something like this :

```
./vendor/bin/atoum -d tests --filter 'not ("needsDatabase" in tags)'
```

Now, we could write something like this :

```
./vendor/bin/atoum -d tests --filter 'not (tags contains "needsDatabase")'
```
