### PR TITLE
launch tests on both stable and lowest versions on dependancies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,13 @@ php:
   - 5.4
   - 5.5
   - 5.6
+env:
+  matrix:
+    - COMPOSER_PREFER="--prefer-stable"
+    - COMPOSER_PREFER="--prefer-lowest"
 notifications:
   irc: "irc.freenode.org##atoum"
 sudo: false
-before_script:
-  - composer install
 script:
+  - composer update $COMPOSER_PREFER
   - ./vendor/bin/atoum


### PR DESCRIPTION
This will allow to also test the extension with the dependancies
on their minimum version. Like that we will be sure that the minimum
version of the dependancies defined in the composer.json also works.
