### PR TITLE
Update Hoa's dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 5.4
   - 5.5
   - 5.6
 env:

--- a/autoloader.php
+++ b/autoloader.php
@@ -11,14 +11,13 @@ if (is_dir($vendorDirectory) === false)
 	$vendorDirectory = __DIR__ . '/../..';
 }
 
-if (is_file($vendorAutoloader = $vendorDirectory . '/hoa/core/Core.php')) {
-	require_once $vendorDirectory . '/hoa/core/Core.php';
+if (is_file($vendorAutoloader = $vendorDirectory . '/hoa/consistency/Prelude.php')) {
+	require_once $vendorDirectory . '/hoa/consistency/Prelude.php';
 }
 
 atoum\autoloader::get()
 	->addNamespaceAlias('atoum\ruler', __NAMESPACE__)
 	->addDirectory(__NAMESPACE__, __DIR__ . '/classes')
-	->addDirectory('Hoa\Core', $vendorDirectory . '/hoa/core')
 	->addDirectory('Hoa\Compiler', $vendorDirectory . '/hoa/compiler')
 	->addDirectory('Hoa\File', $vendorDirectory . '/hoa/file')
 	->addDirectory('Hoa\Iterator', $vendorDirectory . '/hoa/iterator')

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "require": {
         "atoum/atoum": ">=1.0,<3.0",
         "hoa/ruler": ">=2.16.01.11,<3.0",
-        "hoa/regex": ">=0.16.01.11,<1.0"
+        "hoa/stream": ">=0.16.01.11,<1.0"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,8 @@
     "name": "atoum/ruler-extension",
     "require": {
         "atoum/atoum": ">=1.0,<3.0",
-        "hoa/ruler": ">=1.15.11.09,<2.0",
-        "hoa/regex": ">=0.15.05.29,<1.0",
-        "hoa/core": ">=2.14.12.10,<3.0"
+        "hoa/ruler": ">=2.16.01.11,<3.0",
+        "hoa/regex": ">=0.16.01.11,<1.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Replace https://github.com/atoum/ruler-extension/pull/28.

`Hoa\Core` has been removed while dropping PHP5.4. Bump all versions!
